### PR TITLE
Add PART failsafes, WhoIsReceived event, LoggedInAs

### DIFF
--- a/ChatSharp/ChatSharp.csproj
+++ b/ChatSharp/ChatSharp.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Events\ServerMOTDEventArgs.cs" />
     <Compile Include="Events\SocketErrorEventArgs.cs" />
     <Compile Include="Events\SupportsEventArgs.cs" />
+    <Compile Include="Events\WhoIsEventArgs.cs" />
     <Compile Include="Handlers\ChannelHandlers.cs" />
     <Compile Include="Handlers\ListingHandlers.cs" />
     <Compile Include="Handlers\MessageHandlers.cs" />

--- a/ChatSharp/Events/WhoIsEventArgs.cs
+++ b/ChatSharp/Events/WhoIsEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ChatSharp.Events
+{
+    public class WhoIsReceivedEventArgs : EventArgs
+    {
+        public WhoIs WhoIsResponse
+        {
+            get;
+            set;
+        }
+
+        public WhoIsReceivedEventArgs(WhoIs whoIsResponse)
+        {
+            WhoIsResponse = whoIsResponse;
+        }
+    }
+}

--- a/ChatSharp/Handlers/ChannelHandlers.cs
+++ b/ChatSharp/Handlers/ChannelHandlers.cs
@@ -31,6 +31,9 @@ namespace ChatSharp.Handlers
 
         public static void HandlePart(IrcClient client, IrcMessage message)
         {
+            if (!client.Channels.Contains(message.Parameters[0]))
+                return; // we already parted the channel, ignore
+
             if (client.User.Match(message.Prefix)) // We've parted this channel
                 client.Channels.Remove(client.Channels[message.Parameters[0]]);
             else // Someone has parted a channel we're already in
@@ -44,8 +47,8 @@ namespace ChatSharp.Handlers
                     if (mode.Value.Contains(user))
                         mode.Value.Remove(user);
                 }
+                client.OnUserPartedChannel(new ChannelUserEventArgs(client.Channels[message.Parameters[0]], new IrcUser(message.Prefix)));
             }
-            client.OnUserPartedChannel(new ChannelUserEventArgs(client.Channels[message.Parameters[0]], new IrcUser(message.Prefix)));
         }
 
         public static void HandleUserListPart(IrcClient client, IrcMessage message)

--- a/ChatSharp/Handlers/MessageHandlers.cs
+++ b/ChatSharp/Handlers/MessageHandlers.cs
@@ -41,6 +41,7 @@ namespace ChatSharp.Handlers
             client.SetHandler("317", UserHandlers.HandleWhoIsIdle);
             client.SetHandler("318", UserHandlers.HandleWhoIsEnd);
             client.SetHandler("319", UserHandlers.HandleWhoIsChannels);
+            client.SetHandler("330", UserHandlers.HandleWhoIsLoggedInAs);
 
             // Listing handlers
             client.SetHandler("367", ListingHandlers.HandleBanListPart);

--- a/ChatSharp/Handlers/UserHandlers.cs
+++ b/ChatSharp/Handlers/UserHandlers.cs
@@ -16,6 +16,12 @@ namespace ChatSharp.Handlers
             whois.User.RealName = message.Parameters[5];
         }
 
+        public static void HandleWhoIsLoggedInAs(IrcClient client, IrcMessage message)
+        {
+            var whois = (WhoIs)client.RequestManager.PeekOperation("WHOIS " + message.Parameters[1]).State;
+            whois.LoggedInAs = message.Parameters[2];
+        }
+
         public static void HandleWhoIsServer(IrcClient client, IrcMessage message)
         {
             var whois = (WhoIs)client.RequestManager.PeekOperation("WHOIS " + message.Parameters[1]).State;
@@ -50,6 +56,7 @@ namespace ChatSharp.Handlers
             var request = client.RequestManager.DequeueOperation("WHOIS " + message.Parameters[1]);
             if (request.Callback != null)
                 request.Callback(request);
+            client.OnWhoIsReceived(new Events.WhoIsReceivedEventArgs((WhoIs) request.State));
         }
     }
 }

--- a/ChatSharp/IrcClient.cs
+++ b/ChatSharp/IrcClient.cs
@@ -363,5 +363,11 @@ namespace ChatSharp
         {
             if (UserKicked != null) UserKicked(this, e);
         }
+
+        public event EventHandler<WhoIsReceivedEventArgs> WhoIsReceived;
+        protected internal virtual void OnWhoIsReceived(WhoIsReceivedEventArgs e)
+        {
+            if (WhoIsReceived != null) WhoIsReceived(this, e);
+        }
     }
 }

--- a/ChatSharp/WhoIs.cs
+++ b/ChatSharp/WhoIs.cs
@@ -20,5 +20,6 @@ namespace ChatSharp
         public int SecondsIdle { get; set; }
         public string Server { get; set; }
         public string ServerInfo { get; set; }
+        public string LoggedInAs { get; set; }
     }
 }


### PR DESCRIPTION
- When a PART message is received, it checks if it still has a reference to that channel, if not it discards it. Also, it only sends an event if the channel still exists after it has been handled
- `WhoIsReceived` just gets all `WhoIs` messages handled.
- `LoggedInAs` is in response code `330`, e.g.:  `:tepper.freenode.net 330 filibuster filibuster bslsk05 :is logged in as` (self-whois from `filibuster`, logged in as `bslsk05`)