### PR TITLE
fix a serious nick-change bug

### DIFF
--- a/ChatSharp/Handlers/MessageHandlers.cs
+++ b/ChatSharp/Handlers/MessageHandlers.cs
@@ -60,7 +60,10 @@ namespace ChatSharp.Handlers
 
         public static void HandleNick(IrcClient client, IrcMessage message)
         {
-            client.User.Nick = message.Parameters[0];
+            if (client.User.Nick == new IrcUser(message.Prefix).Nick)
+            {
+                client.User.Nick = message.Parameters[0];
+            }
         }
 
         public static void HandlePing(IrcClient client, IrcMessage message)


### PR DESCRIPTION
This bug was causing client.User.Nick to be changed whenever someone else changed their nick. Which was wrong. So a check is added to make sure it was this user who changed the nick otherwise do not update self-nick.