### PR TITLE
fix whois crash bugs

### DIFF
--- a/ChatSharp/Handlers/UserHandlers.cs
+++ b/ChatSharp/Handlers/UserHandlers.cs
@@ -9,9 +9,9 @@ namespace ChatSharp.Handlers
     {
         public static void HandleWhoIsUser(IrcClient client, IrcMessage message)
         {
-            var whois = (WhoIs)client.RequestManager.PeekOperation("WHOIS " + message.Parameters[1]).State;
             if (message.Parameters != null && message.Parameters.Length >= 6)
             {
+                var whois = (WhoIs)client.RequestManager.PeekOperation("WHOIS " + message.Parameters[1]).State;
                 whois.User.Nick = message.Parameters[1];
                 whois.User.User = message.Parameters[2];
                 whois.User.Hostname = message.Parameters[3];

--- a/ChatSharp/RequestManager.cs
+++ b/ChatSharp/RequestManager.cs
@@ -23,7 +23,8 @@ namespace ChatSharp
 
         public RequestOperation PeekOperation(string key)
         {
-            return PendingOperations[key];
+            var realKey = PendingOperations.Keys.FirstOrDefault(k => string.Compare(k, key, StringComparison.OrdinalIgnoreCase) == 0);
+            return PendingOperations[realKey];
         }
 
         public RequestOperation DequeueOperation(string key)


### PR DESCRIPTION
This patch is going to fix whois crash bugs in following 2 scenarios

1. When you whois a user with the nick cased other than the case on server (SomeNick instead of somenick), the response comes back containing the nick with the case on server. Since we are storing the state in dictionary and the nick is part of the key which is case-sensitive; extra work has to be done to locate the key regardless of the case.

2. If we whois a user that is not connected, the response does not contain all the additional fields, a check is placed to make sure the response is right size.