### PR TITLE
QUIT handler added, channel name case bug fix

### DIFF
--- a/ChatSharp/ChannelCollection.cs
+++ b/ChatSharp/ChannelCollection.cs
@@ -51,7 +51,7 @@ namespace ChatSharp
         {
             get
             {
-                var channel = Channels.FirstOrDefault(c => c.Name == name);
+                var channel = Channels.FirstOrDefault(c => c.Name == name.ToLower());
                 if (channel == null)
                     throw new KeyNotFoundException();
                 return channel;


### PR DESCRIPTION
Fixed a bug where channel name was cased differently on server than client had stored in internal state. And QUIT message handler added when other users quit, it removes their state data from channels collection.