### PR TITLE
code smell fix, string comparison

### DIFF
--- a/ChatSharp/ChannelCollection.cs
+++ b/ChatSharp/ChannelCollection.cs
@@ -51,7 +51,7 @@ namespace ChatSharp
         {
             get
             {
-                var channel = Channels.FirstOrDefault(c => c.Name == name.ToLower());
+                var channel = Channels.FirstOrDefault(c => string.Compare(c.Name, name, StringComparison.OrdinalIgnoreCase) == 0);
                 if (channel == null)
                     throw new KeyNotFoundException();
                 return channel;


### PR DESCRIPTION
Realized that I left a codesmell in there. The could would've worked only if we do clients.JoinChannel() and supply channel names in lower cases only. So now I have changed that comparison to "case ignore" comparison.