### PR TITLE
Added HandleMOTDNotFound to MOTDHandlers

### DIFF
--- a/ChatSharp/Handlers/MOTDHandlers.cs
+++ b/ChatSharp/Handlers/MOTDHandlers.cs
@@ -26,6 +26,20 @@ namespace ChatSharp.Handlers
             client.OnMOTDRecieved(new ServerMOTDEventArgs(MOTD));
             client.OnConnectionComplete(new EventArgs());
             // Verify our identity
+            VerifyOurIdentity(client);
+            
+        }
+
+	public static void HandleMOTDNotFound(IrcClient client, IrcMessage message)
+	{
+            client.OnMOTDRecieved(new ServerMOTDEventArgs(MOTD));
+            client.OnConnectionComplete(new EventArgs());
+
+            VerifyOurIdentity(client);
+	}
+
+	private static void VerifyOurIdentity(IrcClient client)
+	{
             if (client.Settings.WhoIsOnConnect)
             {
                 client.WhoIs(client.User.Nick, whois =>

--- a/ChatSharp/Handlers/MessageHandlers.cs
+++ b/ChatSharp/Handlers/MessageHandlers.cs
@@ -24,6 +24,7 @@ namespace ChatSharp.Handlers
             client.SetHandler("375", MOTDHandlers.HandleMOTDStart);
             client.SetHandler("372", MOTDHandlers.HandleMOTD);
             client.SetHandler("376", MOTDHandlers.HandleEndOfMOTD);
+            client.SetHandler("422", MOTDHandlers.HandleMOTDNotFound);
 
             // Channel handlers
             client.SetHandler("JOIN", ChannelHandlers.HandleJoin);


### PR DESCRIPTION
My server did not have a MOTD file, so when the client connects, instead of serving the MOTD it just says 422 "MOTD file missing". ChatSharp just stopped at that point, because it never issued the OnConnectionComplete Event.
I added a handler for that case. I made the whois stuff its own method, because it must now be done in two methods.

I'm not sure what others use the MOTD for, but I hope everybody checks for an empty string :)