### PR TITLE
Unity 5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _ReSharper*
 bin/
 obj/
+packages/
 *.suo
 *.userprefs

--- a/ChatSharp/ChatSharp.csproj
+++ b/ChatSharp/ChatSharp.csproj
@@ -11,6 +11,8 @@
     <FileAlignment>512</FileAlignment>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,9 +35,11 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Threading.Tasks.NET35">
+      <HintPath>..\packages\System.Threading.Tasks.Unofficial.3.1\lib\net35\System.Threading.Tasks.NET35.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -79,7 +83,9 @@
     <Compile Include="UserPoolView.cs" />
     <Compile Include="Events\UserEventArgs.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ChatSharp/Handlers/ChannelHandlers.cs
+++ b/ChatSharp/Handlers/ChannelHandlers.cs
@@ -53,7 +53,7 @@ namespace ChatSharp.Handlers
             var users = message.Parameters[3].Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
             foreach (var nick in users)
             {
-                if (string.IsNullOrWhiteSpace(nick))
+                if (String.IsNullOrEmpty(nick) || nick.Trim().Length == 0)
                     continue;
                 var mode = client.ServerInfo.GetModeForPrefix(nick[0]);
                 if (mode == null)

--- a/ChatSharp/packages.config
+++ b/ChatSharp/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Threading.Tasks.Unofficial" version="3.1" targetFramework="net35" />
+</packages>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ChatSharp
+# ChatSharp for Unity
 
 A C# library for chatting on an IRC (Internet Relay Protocol) network.
 

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<repositories>
+  <repository path="..\ChatSharp\packages.config" />
+</repositories>


### PR DESCRIPTION
Wanted to use this library with a [Unity](http://unity3d.com/) project, but Unity 5 only supports .NET Framework up to 3.5.

To broaden support, I used the [System.Threading.Tasks.Unofficial](https://www.nuget.org/packages/System.Threading.Tasks.Unofficial/) NuGet package to get tasks working and lowered the general dependency to .NET Framework 3.5 in the project file.

([Usage reference](https://github.com/ViMaSter/MOBAdontevenknow/blob/476145799ef1a71882c1bbbf2abd754d5a91f91f/0_unity/Assets/Scripts/Debug/IRCClient.cs))