### PR TITLE
Add support for IRCv3 message tags

### DIFF
--- a/ChatSharp/IrcMessage.cs
+++ b/ChatSharp/IrcMessage.cs
@@ -25,6 +25,10 @@ namespace ChatSharp
         /// Additional parameters supplied with the message.
         /// </summary>
         public string[] Parameters { get; private set; }
+        /// <summary>
+        /// The message tags.
+        /// </summary>
+        public KeyValuePair<string, string>[] Tags { get; private set; }
 
         /// <summary>
         /// Initializes and decodes an IRC message, given the raw message from the server.
@@ -32,6 +36,31 @@ namespace ChatSharp
         public IrcMessage(string rawMessage)
         {
             RawMessage = rawMessage;
+
+            if (rawMessage.StartsWith("@"))
+            {
+                var rawTags = rawMessage.Substring(1, rawMessage.IndexOf(' ') - 1);
+                rawMessage = rawMessage.Substring(rawMessage.IndexOf(' ') + 1);
+
+                // Parse tags as key value pairs
+                var tags = new List<KeyValuePair<string, string>>();
+                foreach (string rawTag in rawTags.Split(';'))
+                {
+                    var replacedTag = rawTag.Replace(@"\:", ";");
+                    KeyValuePair<string, string> tag = new KeyValuePair<string, string>(replacedTag, string.Empty);
+
+                    if (replacedTag.Contains("="))
+                    {
+                        string key = replacedTag.Substring(0, replacedTag.IndexOf("="));
+                        string value = replacedTag.Substring(replacedTag.IndexOf("=") + 1);
+                        tag = new KeyValuePair<string, string>(key, value);
+                    }
+
+                    tags.Add(tag);
+                }
+
+                Tags = tags.ToArray();
+            }
 
             if (rawMessage.StartsWith(":"))
             {

--- a/ChatSharpTests/IrcMessageTests.cs
+++ b/ChatSharpTests/IrcMessageTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using ChatSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 
 namespace ChatSharp.Tests
 {
@@ -40,6 +41,45 @@ namespace ChatSharp.Tests
             IrcMessage fromMessage = new IrcMessage(@":user!~ident@host PRIVMSG target :Lorem ipsum dolor sit amet");
             string[] compareParams = new string[] { "target", "Lorem ipsum dolor sit amet" };
             CollectionAssert.AreEqual(fromMessage.Parameters, compareParams);
+        }
+
+        [TestMethod]
+        public void NewValidMessage_Tags()
+        {
+            IrcMessage fromMessage = new IrcMessage("@a=123;b=456;c=789 :user!~ident@host PRIVMSG target :Lorem ipsum dolor sit amet");
+            KeyValuePair<string, string>[] compareTags = new KeyValuePair<string, string>[]
+            {
+                new KeyValuePair<string, string>("a", "123"),
+                new KeyValuePair<string, string>("b", "456"),
+                new KeyValuePair<string, string>("c", "789")
+            };
+            CollectionAssert.AreEqual(fromMessage.Tags, compareTags);
+        }
+
+        [TestMethod]
+        public void NewValidMessage_Tags02()
+        {
+            IrcMessage fromMessage = new IrcMessage("@aaa=bbb;ccc;example.com/ddd=eee :nick!ident@host.com PRIVMSG me :Hello");
+            KeyValuePair<string, string>[] compareTags = new KeyValuePair<string, string>[]
+            {
+                new KeyValuePair<string, string>("aaa", "bbb"),
+                new KeyValuePair<string, string>("ccc", ""),
+                new KeyValuePair<string, string>("example.com/ddd", "eee"),
+            };
+            CollectionAssert.AreEqual(fromMessage.Tags, compareTags);
+        }
+
+        [TestMethod]
+        public void NewValidMessage_TagsWithSemicolon()
+        {
+            IrcMessage fromMessage = new IrcMessage(@"@a=123\:456;b=456\:789;c=789\:123 :user!~ident@host PRIVMSG target :Lorem ipsum dolor sit amet");
+            KeyValuePair<string, string>[] compareTags = new KeyValuePair<string, string>[]
+            {
+                new KeyValuePair<string, string>("a", "123;456"),
+                new KeyValuePair<string, string>("b", "456;789"),
+                new KeyValuePair<string, string>("c", "789;123"),
+            };
+            CollectionAssert.AreEqual(fromMessage.Tags, compareTags);
         }
     }
 }


### PR DESCRIPTION
As defined in IRCv3, using the following spec as reference: http://ircv3.net/specs/core/message-tags-3.2.html