### PR TITLE
Check if user is not in channel before joining it

### DIFF
--- a/ChatSharp/Handlers/ChannelHandlers.cs
+++ b/ChatSharp/Handlers/ChannelHandlers.cs
@@ -12,9 +12,14 @@ namespace ChatSharp.Handlers
         {
             var channel = client.Channels.GetOrAdd(message.Parameters[0]);
             var user = client.Users.GetOrAdd(message.Prefix);
-            user.Channels.Add(channel);
+
             if (channel != null)
+            {
+                if (!user.Channels.Contains(channel))
+                    user.Channels.Add(channel);
+
                 client.OnUserJoinedChannel(new ChannelUserEventArgs(channel, new IrcUser(message.Prefix)));
+            }
         }
 
         public static void HandleGetTopic(IrcClient client, IrcMessage message)


### PR DESCRIPTION
Moved the join logic to the null check statement because it wouldn't make sense to add a null channel to a user.

I was trying to tackle #54 but some witchcraft is happening. When the `ChatSharp` client leaves, it's not properly updating its channel list, leaving the parted channel there. I also noticed that sometimes the `Client` member of the channel will be set to null after parting. I tried a bunch of ways to try and remove the channel from the client's collection, but none worked.

Thinking about it, I realized that the current code is a bit redundant. You have at least three different ways of accessing `IrcClient`'s channels: either via `client.Channels`, `client.User.Channels` or `client.Users.Get(message.Prefix).Channels`.