### PR TITLE
Fix channel issues

### DIFF
--- a/ChatSharp/Handlers/ChannelHandlers.cs
+++ b/ChatSharp/Handlers/ChannelHandlers.cs
@@ -18,7 +18,7 @@ namespace ChatSharp.Handlers
                 if (!user.Channels.Contains(channel))
                     user.Channels.Add(channel);
 
-                client.OnUserJoinedChannel(new ChannelUserEventArgs(channel, new IrcUser(message.Prefix)));
+                client.OnUserJoinedChannel(new ChannelUserEventArgs(channel, user));
             }
         }
 

--- a/ChatSharp/Handlers/ChannelHandlers.cs
+++ b/ChatSharp/Handlers/ChannelHandlers.cs
@@ -58,31 +58,25 @@ namespace ChatSharp.Handlers
         {
             var channel = client.Channels[message.Parameters[2]];
             var users = message.Parameters[3].Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            foreach (var nick in users)
+            foreach (var rawNick in users)
             {
-                if (string.IsNullOrWhiteSpace(nick))
+                if (string.IsNullOrWhiteSpace(rawNick))
                     continue;
-                var mode = client.ServerInfo.GetModeForPrefix(nick[0]);
-                if (mode == null)
-                {
-                    var user = client.Users.GetOrAdd(nick);
-                    if (!user.Channels.Contains(channel))
-                        user.Channels.Add(channel);
-                    if (!user.ChannelModes.ContainsKey(channel))
-                        user.ChannelModes.Add(channel, null);
-                    else
-                        user.ChannelModes[channel] = null;
-                }
+
+                var nick = rawNick;
+                var modes = client.ServerInfo.GetModesForNick(nick);
+
+                if (modes.Count > 0)
+                    nick = rawNick.Remove(0, modes.Count);
+
+                var user = client.Users.GetOrAdd(nick);
+
+                if (!user.Channels.Contains(channel))
+                    user.Channels.Add(channel);
+                if (!user.ChannelModes.ContainsKey(channel))
+                    user.ChannelModes.Add(channel, modes);
                 else
-                {
-                    var user = client.Users.GetOrAdd(nick.Substring(1));
-                    if (!user.Channels.Contains(channel))
-                        user.Channels.Add(channel);
-                    if (!user.ChannelModes.ContainsKey(channel))
-                        user.ChannelModes.Add(channel, mode.Value);
-                    else
-                        user.ChannelModes[channel] = mode.Value;
-                }
+                    user.ChannelModes[channel] = modes;
             }
         }
 

--- a/ChatSharp/Handlers/ChannelHandlers.cs
+++ b/ChatSharp/Handlers/ChannelHandlers.cs
@@ -10,8 +10,8 @@ namespace ChatSharp.Handlers
     {
         public static void HandleJoin(IrcClient client, IrcMessage message)
         {
-            var channel = client.Channels.GetOrAdd(message.Parameters[0]);
             var user = client.Users.GetOrAdd(message.Prefix);
+            var channel = client.Channels.GetOrAdd(message.Parameters[0]);
 
             if (channel != null)
             {

--- a/ChatSharp/Handlers/ChannelHandlers.cs
+++ b/ChatSharp/Handlers/ChannelHandlers.cs
@@ -48,8 +48,10 @@ namespace ChatSharp.Handlers
 
             if (user.Channels.Contains(channel))
                 user.Channels.Remove(channel);
-            client.OnUserPartedChannel(new ChannelUserEventArgs(client.Channels[message.Parameters[0]],
-                new IrcUser(message.Prefix)));
+            if (user.ChannelModes.ContainsKey(channel))
+                user.ChannelModes.Remove(channel);
+
+            client.OnUserPartedChannel(new ChannelUserEventArgs(channel, user));
         }
 
         public static void HandleUserListPart(IrcClient client, IrcMessage message)

--- a/ChatSharp/Handlers/MessageHandlers.cs
+++ b/ChatSharp/Handlers/MessageHandlers.cs
@@ -1,5 +1,6 @@
 using ChatSharp.Events;
 using System.Linq;
+using System.Collections.Generic;
 using System;
 
 namespace ChatSharp.Handlers
@@ -182,15 +183,16 @@ namespace ChatSharp.Handlers
                                     new UserPoolView(channel.Users.Where(u =>
                                     {
                                         if (!u.ChannelModes.ContainsKey(channel))
-                                            u.ChannelModes.Add(channel, null);
-                                        return u.ChannelModes[channel] == c;
+                                            u.ChannelModes.Add(channel, new List<char?>());
+                                        return u.ChannelModes[channel].Contains(c);
                                     })));
                             }
                             var user = new IrcUser(message.Parameters[i]);
                             if (add)
                             {
                                 if (!channel.UsersByMode[c].Contains(user.Nick))
-                                    user.ChannelModes[channel] = c;
+                                    if (!user.ChannelModes[channel].Contains(c))
+                                        user.ChannelModes[channel].Add(c);
                             }
                             else
                             {

--- a/ChatSharp/IrcChannel.cs
+++ b/ChatSharp/IrcChannel.cs
@@ -107,5 +107,34 @@ namespace ChatSharp
         {
             Client.ChangeMode(Name, change);
         }
+
+        /// <summary>
+        /// True if this channel is equal to another (compares names).
+        /// </summary>
+        /// <returns></returns>
+        public bool Equals(IrcChannel other)
+        {
+            return other.Name == Name;
+        }
+
+        /// <summary>
+        /// True if this channel is equal to another (compares names).
+        /// </summary>
+        /// <returns></returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is IrcChannel)
+                return Equals((IrcChannel)obj);
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the hash code of the channel's name.
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode();
+        }
     }
 }

--- a/ChatSharp/IrcClient.Commands.cs
+++ b/ChatSharp/IrcClient.Commands.cs
@@ -58,7 +58,6 @@ namespace ChatSharp
             if (!Channels.Contains(channel))
                 throw new InvalidOperationException("Client is not present in channel.");
             SendRawMessage("PART {0}", channel);
-            Channels.Remove(Channels[channel]);
         }
 
         /// <summary>
@@ -69,7 +68,6 @@ namespace ChatSharp
             if (!Channels.Contains(channel))
                 throw new InvalidOperationException("Client is not present in channel.");
             SendRawMessage("PART {0} :{1}", channel, reason);
-            Channels.Remove(Channels[channel]);
         }
 
         /// <summary>

--- a/ChatSharp/IrcClient.cs
+++ b/ChatSharp/IrcClient.cs
@@ -158,7 +158,7 @@ namespace ChatSharp
             Users = new UserPool();
             Users.Add(User); // Add self to user pool
             Capabilities = new CapabilityPool();
-            Capabilities.AddRange(new string[] { "server-time" }); // List of supported capabilities
+            Capabilities.AddRange(new string[] { "server-time", "multi-prefix" }); // List of supported capabilities
         }
 
         /// <summary>

--- a/ChatSharp/IrcClient.cs
+++ b/ChatSharp/IrcClient.cs
@@ -146,7 +146,6 @@ namespace ChatSharp
             User = user;
             ServerAddress = serverAddress;
             Encoding = Encoding.UTF8;
-            Channels = new ChannelCollection(this);
             Settings = new ClientSettings();
             Handlers = new Dictionary<string, MessageHandler>();
             MessageHandlers.RegisterDefaultHandlers(this);
@@ -155,6 +154,7 @@ namespace ChatSharp
             WriteQueue = new ConcurrentQueue<string>();
             ServerInfo = new ServerInfo();
             PrivmsgPrefix = "";
+            Channels = User.Channels = new ChannelCollection(this);
             Users = new UserPool();
             Users.Add(User); // Add self to user pool
             Capabilities = new CapabilityPool();

--- a/ChatSharp/IrcUser.cs
+++ b/ChatSharp/IrcUser.cs
@@ -12,7 +12,7 @@ namespace ChatSharp
         internal IrcUser()
         {
             Channels = new ChannelCollection();
-            ChannelModes = new Dictionary<IrcChannel, char?>();
+            ChannelModes = new Dictionary<IrcChannel, List<char?>>();
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace ChatSharp
         /// <value>The channels.</value>
         public ChannelCollection Channels { get; set; }
 
-        internal Dictionary<IrcChannel, char?> ChannelModes { get; set; }
+        internal Dictionary<IrcChannel, List<char?>> ChannelModes { get; set; }
 
         /// <summary>
         /// This user's hostmask (nick!user@host).

--- a/ChatSharp/ServerInfo.cs
+++ b/ChatSharp/ServerInfo.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace ChatSharp
 {
     /// <summary>
@@ -8,7 +11,7 @@ namespace ChatSharp
         internal ServerInfo()
         {
             // Guess for some defaults
-            Prefixes = new[] { "ov", "@+" };
+            Prefixes = new[] { "ovhaq", "@+%&~" };
             SupportedChannelModes = new ChannelModes();
             IsGuess = true;
         }
@@ -21,6 +24,35 @@ namespace ChatSharp
             if (Prefixes[1].IndexOf(prefix) == -1)
                 return null;
             return Prefixes[0][Prefixes[1].IndexOf(prefix)];
+        }
+
+        /// <summary>
+        /// Gets the channel modes for a given user nick.
+        /// Returns an empty array if user has no modes.
+        /// </summary>
+        /// <returns></returns>
+        public List<char?> GetModesForNick(string nick)
+        {
+            var supportedPrefixes = Prefixes[1];
+            List<char?> modeList = new List<char?>();
+            List<char> nickPrefixes = new List<char>();
+
+            foreach (char prefix in supportedPrefixes)
+            {
+                if (nick.Contains(prefix))
+                {
+                    nick.Remove(nick.IndexOf(prefix));
+                    if (!nickPrefixes.Contains(prefix))
+                    {
+                        nickPrefixes.Add(prefix);
+                        var mode = GetModeForPrefix(prefix);
+                        if (!modeList.Contains(mode))
+                            modeList.Add(mode);
+                    }
+                }
+            }
+
+            return modeList;
         }
 
         /// <summary>
@@ -97,7 +129,7 @@ namespace ChatSharp
                 ParameterizedSettings = "k";
                 OptionallyParameterizedSettings = "flj";
                 Settings = string.Empty;
-                ChannelUserModes = "vo"; // I have no idea what I'm doing here
+                ChannelUserModes = "vhoaq"; // I have no idea what I'm doing here
             }
 
             /// <summary>

--- a/ChatSharp/UserPoolView.cs
+++ b/ChatSharp/UserPoolView.cs
@@ -9,7 +9,6 @@ namespace ChatSharp
     /// </summary>
     public class UserPoolView : IEnumerable<IrcUser>
     {
-        private UserPool Pool { get; set; }
         private IEnumerable<IrcUser> Users { get; set; }
 
         internal UserPoolView(IEnumerable<IrcUser> users)

--- a/ChatSharpTests/ChatSharp.Tests.csproj
+++ b/ChatSharpTests/ChatSharp.Tests.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IrcMessageTests.cs" />
+    <Compile Include="IrcUserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ChatSharpTests/IrcUserTests.cs
+++ b/ChatSharpTests/IrcUserTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using ChatSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ChatSharp.Tests
+{
+    [TestClass]
+    public class IrcUserTests
+    {
+        [TestMethod]
+        public void GetUserModes_NotNull_FiveModes()
+        {
+            IrcUser user = new IrcUser("~&@%+aji", "user");
+            IrcClient client = new IrcClient("irc.address", user);
+
+            var userModes = client.ServerInfo.GetModesForNick(user.Nick);
+
+            Assert.IsTrue(userModes.Count == 5);
+        }
+
+        [TestMethod]
+        public void GetUserModes_NotNull_FourModes()
+        {
+            IrcUser user = new IrcUser("&@%+aji", "user");
+            IrcClient client = new IrcClient("irc.address", user);
+
+            var userModes = client.ServerInfo.GetModesForNick(user.Nick);
+
+            Assert.IsTrue(userModes.Count == 4);
+        }
+
+        [TestMethod]
+        public void GetUserModes_NotNull_ThreeModes()
+        {
+            IrcUser user = new IrcUser("@%+aji", "user");
+            IrcClient client = new IrcClient("irc.address", user);
+
+            var userModes = client.ServerInfo.GetModesForNick(user.Nick);
+
+            Assert.IsTrue(userModes.Count == 3);
+        }
+
+        [TestMethod]
+        public void GetUserModes_NotNull_TwoModes()
+        {
+            IrcUser user = new IrcUser("%+aji", "user");
+            IrcClient client = new IrcClient("irc.address", user);
+
+            var userModes = client.ServerInfo.GetModesForNick(user.Nick);
+
+            Assert.IsTrue(userModes.Count == 2);
+        }
+
+        [TestMethod]
+        public void GetUserModes_NotNull_OneMode()
+        {
+            IrcUser user = new IrcUser("+aji", "user");
+            IrcClient client = new IrcClient("irc.address", user);
+
+            var userModes = client.ServerInfo.GetModesForNick(user.Nick);
+
+            Assert.IsTrue(userModes.Count == 1);
+        }
+
+        [TestMethod]
+        public void GetUserModes_IsNull()
+        {
+            IrcUser user = new IrcUser("aji", "user");
+            IrcClient client = new IrcClient("irc.address", user);
+
+            var userModes = client.ServerInfo.GetModesForNick(user.Nick);
+
+            Assert.IsTrue(userModes.Count == 0);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #54.

This is a series of commits trying to fix the issue described in #54. The actual fix was pretty simple: just mirror `client.Channels` to `client.User.Channels`. With that done, there is no need for a special logic to check if the current user who parted the channel is the library client and act accordingly.

However, as stated in the issue linked above, I've also managed to fix the user modes bug that appeared by adding a equality check to `IrcChannel`. C#, by default, will compare two objects based on their members if the equality operator isn't overridden.